### PR TITLE
Remove not needed parameter of AggregateRepository.findAll

### DIFF
--- a/src/main/java/com/hltech/store/AggregateRepository.java
+++ b/src/main/java/com/hltech/store/AggregateRepository.java
@@ -16,8 +16,8 @@ public class AggregateRepository<A, E> {
     private final BiFunction<A, E, A> eventApplier;
     private final BiFunction<A, Integer, A> aggregateVersionApplier;
 
-    public <P extends EventStore<E>> AggregateRepository(
-            P eventStore,
+    public AggregateRepository(
+            EventStore<E> eventStore,
             String aggregateName,
             Supplier<A> initialAggregateStateSupplier,
             BiFunction<A, E, A> eventApplier,
@@ -30,8 +30,8 @@ public class AggregateRepository<A, E> {
         this.aggregateVersionApplier = aggregateVersionApplier;
     }
 
-    public <P extends EventStore<E>> AggregateRepository(
-            P eventStore,
+    public AggregateRepository(
+            EventStore<E> eventStore,
             String aggregateName,
             Supplier<A> initialAggregateStateSupplier,
             BiFunction<A, E, A> eventApplier

--- a/src/main/java/com/hltech/store/AggregateRepository.java
+++ b/src/main/java/com/hltech/store/AggregateRepository.java
@@ -75,7 +75,7 @@ public class AggregateRepository<A, E> {
                 .orElseThrow(() -> new AggregateRepositoryException("Could not find aggregate to event: " + toEvent + " for aggregate name: " + aggregateName));
     }
 
-    public List<A> findAll(String aggregateName) {
+    public List<A> findAll() {
         return eventStore
                 .findAll(aggregateName)
                 .values()

--- a/src/main/java/com/hltech/store/AggregateRepository.java
+++ b/src/main/java/com/hltech/store/AggregateRepository.java
@@ -16,8 +16,8 @@ public class AggregateRepository<A, E> {
     private final BiFunction<A, E, A> eventApplier;
     private final BiFunction<A, Integer, A> aggregateVersionApplier;
 
-    public AggregateRepository(
-            EventStore<E> eventStore,
+    public <P extends EventStore<E>> AggregateRepository(
+            P eventStore,
             String aggregateName,
             Supplier<A> initialAggregateStateSupplier,
             BiFunction<A, E, A> eventApplier,
@@ -30,8 +30,8 @@ public class AggregateRepository<A, E> {
         this.aggregateVersionApplier = aggregateVersionApplier;
     }
 
-    public AggregateRepository(
-            EventStore<E> eventStore,
+    public <P extends EventStore<E>> AggregateRepository(
+            P eventStore,
             String aggregateName,
             Supplier<A> initialAggregateStateSupplier,
             BiFunction<A, E, A> eventApplier

--- a/src/test/unit/com/hltech/store/AggregateRepositoryUT.groovy
+++ b/src/test/unit/com/hltech/store/AggregateRepositoryUT.groovy
@@ -169,13 +169,13 @@ class AggregateRepositoryUT extends Specification {
 
     }
 
-    def "findAll should return all aggregates within stream"() {
+    def "findAll should return all aggregates with name"() {
 
-        given: 'Events for aggregate exists in event store for stream'
+        given: 'Events for aggregate exists in event store for aggregate name'
             eventStore.findAll(AGGREGATE_NAME) >> [AGGREGATE_ID: [EVENT] ]
 
         when: 'Search for aggregates'
-            List<DummyAggregate> aggregates = repository.findAll(AGGREGATE_NAME)
+            List<DummyAggregate> aggregates = repository.findAll()
 
         then: 'Aggregates found'
             aggregates.size() == 1
@@ -188,13 +188,13 @@ class AggregateRepositoryUT extends Specification {
 
     }
 
-    def "findAll should return empty list when there is no events in the stream"() {
+    def "findAll should return empty list when there is no events related to aggregate name"() {
 
-        given: 'Events does not exists in event store for stream'
+        given: 'Events does not exists in event store for aggregate name'
             eventStore.findAll(AGGREGATE_NAME) >> [:]
 
         when: 'Search for aggregates'
-            List<DummyAggregate> aggregates = repository.findAll(AGGREGATE_NAME)
+            List<DummyAggregate> aggregates = repository.findAll()
 
         then: 'Aggregates not found'
             aggregates.empty


### PR DESCRIPTION
- Ability to create AggregateRepository using class that extends EventStore
- Remove not needed parameter of AggregateRepository.findAll